### PR TITLE
Change MAX_KEY_CODE to 182

### DIFF
--- a/keydogger.h
+++ b/keydogger.h
@@ -9,7 +9,7 @@
 #define READABLE_KEYS 126
 #define LINUX_KEYS 50
 
-#define MAX_KEY_CODE 181
+#define MAX_KEY_CODE 182
 
 #define FLAG_UPPERCASE 128
 


### PR DESCRIPTION
Fixes an issue with undefined behavior in https://github.com/jarusll/keydogger/blob/7c0a30ff442744a986e10282997acb347f92cd60/keydogger.c#L204
since `KEY_SLASH | FLAG_UPPERCASE` evaluates to `181`, causing an OOB write on `key_codes_to_position` which was initialized at `181` previously